### PR TITLE
Increase specificity from 1-0-0-0-0 to 1-0-20-0-0

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,3 +1,3 @@
-* {
+*:not(#a#b):not(#a#b):not(#a#b):not(#a#b):not(#a#b):not(#a#b):not(#a#b):not(#a#b):not(#a#b):not(#a#b) {
   hyphens: none !important;
 }


### PR DESCRIPTION
This fixes the hyphenation still [occurring](https://addons.mozilla.org/en-CA/firefox/addon/disable-hyphenation/reviews/1940726/) on some websites like the [StackExchange](https://stackexchange.com) network. Those sites combine element and class selectors with `!important` to attain a [specificity](https://specifishity.com/) of 1-0-0-1-1, which overrode our previous specificity of 1-0-0-0-0.

By adding 10 copies of `:not(#a#b)`, the ID specificity is raised to 20. Each `:not(...)` has the specificity of its children. `#a#b` is of specificity 2-0-0, but it's impossible for an element to have two IDs. The `:not` of "impossible" is "always", so this works for all elements no matter the ID, and selects the same elements as "*".